### PR TITLE
[DOCS] Fix README.md Navigation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@
 <p>
 <a href="#wrench-installation">Installation</a> |
 <a href="#sparkles-features">Features</a> |
-<a href="#running-quick-start">Quick-Start</a> |
+<a href="#rocket-quick-start">Quick-Start</a> |
 <a href="#gear-components"> Components</a> |
 <a href="#robot-supporting-methods"> Supporting Methods</a> |
-<a href="#notebook-supporting-datasets"> Supporting Datasets</a> |
+<a href="#notebook-supporting-datasets--document-corpus"> Supporting Datasets</a> |
 <a href="#raised_hands-additional-faqs"> FAQs</a>
 </p>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ transformers>=4.40.0
 bm25s[core]==0.2.0
 fschat
 streamlit
+chonkie

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,3 @@ transformers>=4.40.0
 bm25s[core]==0.2.0
 fschat
 streamlit
-chonkie


### PR DESCRIPTION
Hey @ FlashRAG Team!

This is a minor edit, but I noticed the navigation links for a few of the options were pointing to the wrong place~ Specifically, `Quick-Start` and `Supporting Documents`. Pointed them to where I believe you intended it to!


<img width="799" alt="image" src="https://github.com/user-attachments/assets/8fe7ba36-cba9-47fb-bfe7-bab62df488f4" />

Thanks! 😊

cc: @ignorejjj 