### PR TITLE
[FEAT] Add Chonkie Chunkers to `process_wiki.py`

### DIFF
--- a/docs/chunk-doc-corpus.md
+++ b/docs/chunk-doc-corpus.md
@@ -24,9 +24,9 @@ python chunk_doc_corpus.py --input_path input.jsonl \
 You will get a JSONL file with the following format:
 
 ```jsonl
-{ "id": 0, "doc_id": 0, "contents": ... }
-{ "id": 1, "doc_id": 0, "contents": ... }
-{ "id": 2, "doc_id": 0, "contents": ... }
+{ "id": 0, "doc_id": 0, "title": ..., "contents": ... }
+{ "id": 1, "doc_id": 0, "title": ..., "contents": ... }
+{ "id": 2, "doc_id": 0, "title": ..., "contents": ... }
 ...
 ```
 

--- a/docs/chunk-doc-corpus.md
+++ b/docs/chunk-doc-corpus.md
@@ -1,0 +1,40 @@
+# Chunking Document Corpus
+
+You can chunk your document corpus into smaller chunks by following these steps. This is useful in building an index over a large corpus of long documents for RAG, or if you want to make sure that the document length is not too long for the model.
+
+Given a JSONL file with the following format:
+
+```json
+{
+    "id": "doc_id",
+    "content": "document_content"
+}
+```
+
+run the following command:
+
+```bash
+cd scripts
+python chunk_doc_corpus.py --input_path input.jsonl \
+                          --output_path output.jsonl \
+                          --chunk_by sentence \
+                          --chunk_size 512
+```
+
+And you will get a JSONL file with the following format:
+
+```json
+{
+    "id": "doc_id",
+    "content": "document_content"
+}
+```
+
+**NOTE:** That `doc_id` will be the same as the original document id, and `content` will be the chunked document content in the new JSONL output.
+
+## Parameters
+
+- `input_path`: Path to the input JSONL file.
+- `output_path`: Path to the output JSONL file.
+- `chunk_by`: Chunking method to use. Can be `token`, `word`, `sentence`, or `recursive`.
+- `chunk_size`: Size of chunks.

--- a/docs/chunk-doc-corpus.md
+++ b/docs/chunk-doc-corpus.md
@@ -2,12 +2,12 @@
 
 You can chunk your document corpus into smaller chunks by following these steps. This is useful in building an index over a large corpus of long documents for RAG, or if you want to make sure that the document length is not too long for the model.
 
-Given a JSONL file with the following format:
+Given a Document Corpus JSONL file with the following format and `contents` field containing the `"{title}\n{text}"` format:
 
 ```jsonl
-{ "id": 0, "contents": ... }
-{ "id": 1, "contents": ... }
-{ "id": 2, "contents": ... }
+{ "id": 0, "contents": "..." }
+{ "id": 1, "contents": "..." }
+{ "id": 2, "contents": "..." }
 ...
 ```
 

--- a/docs/chunk-doc-corpus.md
+++ b/docs/chunk-doc-corpus.md
@@ -4,14 +4,14 @@ You can chunk your document corpus into smaller chunks by following these steps.
 
 Given a JSONL file with the following format:
 
-```json
-{
-    "id": "doc_id",
-    "contents": "document_content"
-}
+```jsonl
+{ "id": 0, "contents": ... }
+{ "id": 1, "contents": ... }
+{ "id": 2, "contents": ... }
+...
 ```
 
-run the following command:
+You can run the following command:
 
 ```bash
 cd scripts
@@ -21,13 +21,13 @@ python chunk_doc_corpus.py --input_path input.jsonl \
                           --chunk_size 512
 ```
 
-And you will get a JSONL file with the following format:
+You will get a JSONL file with the following format:
 
-```json
-{
-    "id": "doc_id",
-    "content": "document_content"
-}
+```jsonl
+{ "id": 0, "doc_id": 0, "contents": ... }
+{ "id": 1, "doc_id": 0, "contents": ... }
+{ "id": 2, "doc_id": 0, "contents": ... }
+...
 ```
 
 **NOTE:** That `doc_id` will be the same as the original document id, and `content` will be the chunked document content in the new JSONL output.

--- a/docs/chunk-doc-corpus.md
+++ b/docs/chunk-doc-corpus.md
@@ -7,7 +7,7 @@ Given a JSONL file with the following format:
 ```json
 {
     "id": "doc_id",
-    "content": "document_content"
+    "contents": "document_content"
 }
 ```
 

--- a/docs/chunk-doc-corpus.md
+++ b/docs/chunk-doc-corpus.md
@@ -30,7 +30,7 @@ You will get a JSONL file with the following format:
 ...
 ```
 
-**NOTE:** That `doc_id` will be the same as the original document id, and `content` will be the chunked document content in the new JSONL output.
+**NOTE:** That `doc_id` will be the same as the original document id, and `contents` will be the chunked document content in the new JSONL output.
 
 ## Parameters
 

--- a/docs/process-wiki.md
+++ b/docs/process-wiki.md
@@ -1,23 +1,8 @@
-## Building Wiki Corpus
+# Building Wiki Corpus
 
 You can create your own wiki corpus by following these steps.
 
-### Step1: Install necessary tools
-
-First, install the required tools:
-```bash
-pip install wikiextractor==0.1
-python -m spacy download en_core_web_lg
-```
-
-If you encounter issues downloading en_core_web_lg, you can manually download it:
-```bash
-wget https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-3.7.1/en_core_web_lg-3.7.1-py3-none-any.whl
-pip install en_core_web_lg-3.7.1-py3-none-any.whl
-```
-
-
-### Step2: Download Wiki dump
+## Step1: Download Wiki dump
 
 Download the Wikipedia dump you require in XML format. For instance: 
 
@@ -27,8 +12,7 @@ wget https://archive.org/download/enwiki-20181220/enwiki-20181220-pages-articles
 
 You can access other dumps from this [<u>website</u>](https://archive.org/search?query=Wikimedia+database+dump&sort=-downloads).
 
-
-### Step3: Run process script
+## Step2: Run process script
 
 Execute the provided script to process the wiki dump into JSONL format. Adjust the corpus partitioning parameters as needed:
 
@@ -36,7 +20,9 @@ Execute the provided script to process the wiki dump into JSONL format. Adjust t
 cd scripts
 python preprocess_wiki.py --dump_path ../enwikinews-20240420-pages-articles.xml.bz2  \
                         --save_path ../test_sample.jsonl \
-                        --chunk_by 100w
+                        --chunk_by sentence \
+                        --chunk_size 512 \
+                        --num_workers 1
 ```
 
 We also provide the version we used for experiments. Download link: https://huggingface.co/datasets/RUC-NLPIR/FlashRAG_datasets/tree/main/retrieval-corpus

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ transformers>=4.40.0
 bm25s[core]==0.2.0
 fschat
 streamlit
+chonkie>=0.4.0

--- a/scripts/chunk_doc_corpus.py
+++ b/scripts/chunk_doc_corpus.py
@@ -26,7 +26,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Chunk documents from a JSONL file.")
     parser.add_argument("--input_path", type=str, required=True, help="Path to input JSONL file")
     parser.add_argument("--output_path", type=str, required=True, help="Path to output JSONL file")
-    parser.add_argument("--chunk_by", default="token", choices=["token", "word", "sentence", "recursive"], 
+    parser.add_argument("--chunk_by", default="token", choices=["token", "word", "sentence", "recursive"],
                         help="Chunking method to use")
     parser.add_argument("--chunk_size", default=512, type=int, help="Size of chunks")
     args = parser.parse_args()
@@ -50,14 +50,17 @@ if __name__ == "__main__":
     # Process and chunk documents
     print("Chunking documents...")
     chunked_documents = []
+    current_chunk_id = 0
     for doc in tqdm(documents):
-        chunks = chunker.chunk(doc['content'])
+        chunks = chunker.chunk(doc['contents'])
         for chunk in chunks:
             chunked_doc = {
-                'id': doc['id'],
-                'content': chunk.text
+                'id': current_chunk_id,
+                'doc_id': doc['id'],
+                'contents': chunk.text
             }
             chunked_documents.append(chunked_doc)
+            current_chunk_id += 1
 
     # Save chunked documents
     print("Saving chunked documents...")

--- a/scripts/chunk_doc_corpus.py
+++ b/scripts/chunk_doc_corpus.py
@@ -1,8 +1,12 @@
+"""Chunk documents from a Document Corpus JSONL file.
+
+This script is used to chunk documents from a Document Corpus JSONL file,
+via Chonkie.
+"""
 import argparse
 import json
 from tqdm import tqdm
 import chonkie
-
 
 def load_jsonl(file_path):
     documents = []

--- a/scripts/chunk_doc_corpus.py
+++ b/scripts/chunk_doc_corpus.py
@@ -1,0 +1,61 @@
+import argparse
+import json
+from tqdm import tqdm
+import chonkie
+
+
+def load_jsonl(file_path):
+    documents = []
+    with open(file_path, 'r', encoding='utf-8') as f:
+        for line in f:
+            documents.append(json.loads(line))
+    return documents
+
+
+def save_jsonl(documents, file_path):
+    with open(file_path, 'w', encoding='utf-8') as f:
+        for doc in documents:
+            f.write(json.dumps(doc) + '\n')
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Chunk documents from a JSONL file.")
+    parser.add_argument("--input_path", type=str, required=True, help="Path to input JSONL file")
+    parser.add_argument("--output_path", type=str, required=True, help="Path to output JSONL file")
+    parser.add_argument("--chunk_by", default="token", choices=["token", "word", "sentence", "recursive"], 
+                        help="Chunking method to use")
+    parser.add_argument("--chunk_size", default=512, type=int, help="Size of chunks")
+    args = parser.parse_args()
+
+    # Load documents
+    print("Loading documents...")
+    documents = load_jsonl(args.input_path)
+
+    # Initialize chunker
+    if args.chunk_by == "token":
+        chunker = chonkie.TokenChunker(chunk_size=args.chunk_size)
+    elif args.chunk_by == "sentence":
+        chunker = chonkie.SentenceChunker(chunk_size=args.chunk_size)
+    elif args.chunk_by == "recursive":
+        chunker = chonkie.RecursiveChunker(chunk_size=args.chunk_size, min_characters_per_chunk=1)
+    elif args.chunk_by == "word":
+        chunker = chonkie.WordChunker(chunk_size=args.chunk_size)
+    else:
+        raise ValueError(f"Invalid chunking method: {args.chunk_by}")
+
+    # Process and chunk documents
+    print("Chunking documents...")
+    chunked_documents = []
+    for doc in tqdm(documents):
+        chunks = chunker.chunk(doc['content'])
+        for chunk in chunks:
+            chunked_doc = {
+                'id': doc['id'],
+                'content': chunk.text
+            }
+            chunked_documents.append(chunked_doc)
+
+    # Save chunked documents
+    print("Saving chunked documents...")
+    save_jsonl(chunked_documents, args.output_path)
+    print(f"Done! Processed {len(documents)} documents into {len(chunked_documents)} chunks.")

--- a/scripts/chunk_doc_corpus.py
+++ b/scripts/chunk_doc_corpus.py
@@ -58,8 +58,8 @@ if __name__ == "__main__":
             chunked_doc = {
                 'id': current_chunk_id,
                 'doc_id': doc['id'],
-                'contents': chunk.text,
-                'title': title
+                'title': title,
+                'contents': title + "\n" + chunk.text,
             }
             chunked_documents.append(chunked_doc)
             current_chunk_id += 1

--- a/scripts/chunk_doc_corpus.py
+++ b/scripts/chunk_doc_corpus.py
@@ -52,12 +52,14 @@ if __name__ == "__main__":
     chunked_documents = []
     current_chunk_id = 0
     for doc in tqdm(documents):
-        chunks = chunker.chunk(doc['contents'])
+        title, text = doc['contents'].split('\n', 1)
+        chunks = chunker.chunk(text)
         for chunk in chunks:
             chunked_doc = {
                 'id': current_chunk_id,
                 'doc_id': doc['id'],
-                'contents': chunk.text
+                'contents': chunk.text,
+                'title': title
             }
             chunked_documents.append(chunked_doc)
             current_chunk_id += 1

--- a/scripts/preprocess_wiki.py
+++ b/scripts/preprocess_wiki.py
@@ -207,7 +207,7 @@ if __name__ == "__main__":
     elif args.chunk_by == "sentence":
         chunker = chonkie.SentenceChunker(chunk_size=args.chunk_size)
     elif args.chunk_by == "recursive":
-        chunker = chonkie.RecursiveChunker(chunk_size=args.chunk_size)
+        chunker = chonkie.RecursiveChunker(chunk_size=args.chunk_size, min_characters_per_chunk=1)
     elif args.chunk_by == "word":
         chunker = chonkie.WordChunker(chunk_size=args.chunk_size)
     else:

--- a/scripts/preprocess_wiki.py
+++ b/scripts/preprocess_wiki.py
@@ -2,7 +2,6 @@ import argparse
 from tqdm import tqdm
 import re
 import html
-import spacy
 import os
 import json
 import subprocess
@@ -10,6 +9,8 @@ from pathlib import Path
 import shutil
 from concurrent.futures import ThreadPoolExecutor
 from multiprocessing import Pool
+
+import chonkie
 
 
 def load_corpus(dir_path):
@@ -38,21 +39,6 @@ def load_corpus(dir_path):
             executor.submit(read_jsonl_file, file_path)
 
     return corpus
-
-
-def create_segments(doc_text, max_length, stride):
-    doc_text = doc_text.strip()
-    doc = nlp(doc_text)
-    sentences = [sent.text.strip() for sent in doc.sents]
-    segments = []
-
-    for i in range(0, len(sentences), stride):
-        segment = " ".join(sentences[i : i + max_length])
-        segments.append(segment)
-        if i + max_length >= len(sentences):
-            break
-
-    return segments
 
 
 def basic_process(title, text):
@@ -164,9 +150,8 @@ def single_worker(docs):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Generate clean wiki corpus file for indexing.")
     parser.add_argument("--dump_path", type=str)
-    parser.add_argument("--chunk_by", default="100w", choices=["100w", "sentence"], type=str)
-    parser.add_argument("--seg_size", default=None, type=int)
-    parser.add_argument("--stride", default=None, type=int)
+    parser.add_argument("--chunk_by", default="token", choices=["token", "word", "sentence", "recursive"], type=str)
+    parser.add_argument("--chunk_size", default=512, type=int)
     parser.add_argument("--num_workers", default=4, type=int)
     parser.add_argument("--save_path", type=str, default="clean_corpus.jsonl")
     args = parser.parse_args()
@@ -191,7 +176,6 @@ if __name__ == "__main__":
     )
 
     corpus = load_corpus(temp_dir)
-    nlp = spacy.load("en_core_web_lg")
 
     documents = {}
     # To avoid duplicate pages
@@ -216,51 +200,24 @@ if __name__ == "__main__":
     print("Start chunking...")
     idx = 0
     clean_corpus = []
-    if args.chunk_by == "sentence":
-        for doc in tqdm(nlp.pipe(all_text, n_process=args.num_workers, batch_size=2000), total=len(all_text)):
-            title = all_title[idx]
-            idx += 1
-            sentences = [sent.text.strip() for sent in doc.sents]
-            segments = []
-            for i in range(0, len(sentences), args.stride):
-                segment = " ".join(sentences[i : i + args.seg_size])
-                segments.append(segment)
-                if i + args.seg_size >= len(sentences):
-                    break
-            for segment in segments:
-                text = segment.replace("\n", " ").replace("\t", " ")
-                clean_corpus.append({"title": title, "text": text})
 
-    elif args.chunk_by == "100w":
-        for doc in tqdm(nlp.pipe(all_text, n_process=args.num_workers, batch_size=2000), total=len(all_text)):
-            title = all_title[idx]
-            idx += 1
-            segments = []
-            word_count = 0
-            segment_tokens = []
-            for token in doc:
-                segment_tokens.append(token.text_with_ws)
-                if not token.is_space and not token.is_punct:
-                    word_count += 1
-                    if word_count == 100:
-                        word_count = 0
-                        segments.append("".join([token for token in segment_tokens]))
-                        segment_tokens = []
-            if word_count != 0:
-                for token in doc:
-                    segment_tokens.append(token.text_with_ws)
-                    if not token.is_space and not token.is_punct:
-                        word_count += 1
-                        if word_count == 100:
-                            word_count = 0
-                            segments.append("".join([token for token in segment_tokens]))
-                            break
-            if word_count != 0:
-                segments.append("".join([token for token in segment_tokens]))
+    # Initialize a Chonkie chunker, based on the chunk_by argument
+    if args.chunk_by == "token":
+        chunker = chonkie.TokenChunker(chunk_size=args.chunk_size)
+    elif args.chunk_by == "sentence":
+        chunker = chonkie.SentenceChunker(chunk_size=args.chunk_size)
+    elif args.chunk_by == "recursive":
+        chunker = chonkie.RecursiveChunker(chunk_size=args.chunk_size)
+    elif args.chunk_by == "word":
+        chunker = chonkie.WordChunker(chunk_size=args.chunk_size)
+    else:
+        raise ValueError(f"Invalid chunking method: {args.chunk_by}")
 
-            for segment in segments:
-                text = segment.replace("\n", " ").replace("\t", " ")
-                clean_corpus.append({"title": title, "text": text})
+    # Chunk the text into segments, with chunker
+    for title, text in tqdm(zip(all_title, all_text), total=len(all_text)):
+        chunks = chunker.chunk(text)
+        for chunk in chunks:
+            clean_corpus.append({"title": title, "text": chunk.text})
 
     shutil.rmtree(temp_dir)
 


### PR DESCRIPTION
Hey @ FlashRAG Team, 👋

I have integrated Chonkie's chunkers for use in the `process_wiki.py` script, as mentioned in #116. As you might notice, the code has significantly shortened as a result. Some noteable changes that I would like to mention are: 

- `chunk_by` now supports the following parameters with chonkie: `[ 'token', 'word', 'sentence', 'recursive' ]`. These are all part of Chonkie's default installation, which is about 11 MB in the latest release.
- `seg_size` has been renamed to `chunk_size` for clarity. Considering `chunk_by` was already a parameter earlier, it is easier to understand `chunk_size`. [please let me know if this is not required; I can change it back.]
- Removed `spacy` import and installation instructions from the docs. Chonkie is independent of spacy. During the entire process, I did not need to install spacy, effectively saving ~500 MB from not installing it. 
- Massive speed-up noticeable. 

|Method  | Original | with Chonkie |
| --------|  --------|----------|
| 100w / word  |9:52    |1:32     |
| Sentence  |15:42 |0:04          |
| Token         | NA   |0:02          |
| Recursive  | NA    |0:02         |

**timings taken on a M3 Macbook, with [enwikinews-20190101-pages-articles.xml.bz2](https://archive.org/download/enwikinews-20190101/enwikinews-20190101-pages-articles.xml.bz2)

- Added a `chunk_document_corpus.py` file as well, which can be used to convert any JSONL file with 'content' keys into another chunked corpus. 


Please let me know if there are any changes required in the PR! 

Thanks 😊