### PR TITLE
📖 Fix typos in `basic_usage.md`

### DIFF
--- a/docs/original_docs/basic_usage.md
+++ b/docs/original_docs/basic_usage.md
@@ -13,11 +13,11 @@ retriever = get_retriever(config)
 Then, you can use `retriever.search` (for a single query) or `retriever.batch_search` (for a list of queries) to perform retrieval.
 
 ```python
-# if you set `return_scores=True`
-retrieval_results, scores = self.retriever.batch_search(input_query_list, return_scores=True)
+# if you set `return_score=True`
+retrieval_results, scores = retriever.batch_search(input_query_list, return_score=True)
 
-# if you set `return_scores=False`
-retrieval_results = self.retriever.batch_search(input_query_list, return_scores=False)
+# if you set `return_score=False`
+retrieval_results = retriever.batch_search(input_query_list, return_score=False)
 ```
 
 When using `batch_search`, `retrieval_results` is a two-level nested list like:


### PR DESCRIPTION
Fix typos in the documentation of dense retriever component to align with the retriever's implementation:
https://github.com/RUC-NLPIR/FlashRAG/blob/ce29961609e3748717bdacf15432bf204b6be376/docs/zh-cn/component/retriever.md?plain=1#L61
and
https://github.com/RUC-NLPIR/FlashRAG/blob/ce29961609e3748717bdacf15432bf204b6be376/flashrag/retriever/retriever.py#L439