### PR TITLE
Fix bm25s `Tokenizer.save_vocab` issue by upgrading `bm25s` and importing correctly

### DIFF
--- a/flashrag/retriever/retriever.py
+++ b/flashrag/retriever/retriever.py
@@ -305,6 +305,8 @@ class BM25Retriever(BaseTextRetriever):
             else:
                 results = load_docs(self.corpus, [hit.docid for hit in hits])
         elif self.backend == "bm25s":
+            import bm25s
+
             # query_tokens = self.tokenizer.tokenize([query], return_as="tuple", update_vocab=False)
             query_tokens = bm25s.tokenize([query])
             results, scores = self.searcher.retrieve(query_tokens, k=num)
@@ -328,6 +330,8 @@ class BM25Retriever(BaseTextRetriever):
                 results.append(item_result)
                 scores.append(item_score)
         elif self.backend == "bm25s":
+            import bm25s
+
             # query_tokens = self.tokenizer.tokenize(query, return_as="tuple", update_vocab=False)
             query_tokens = bm25s.tokenize(query)
             results, scores = self.searcher.retrieve(query_tokens, k=num)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ tiktoken
 torch
 tqdm
 transformers>=4.40.0
-bm25s[core]==0.2.0
+bm25s[core]==0.2.1
 fschat
 streamlit
 chonkie>=1.0.2, <1.1.0


### PR DESCRIPTION
## Description

This PR addresses issue https://github.com/RUC-NLPIR/FlashRAG/issues/178 where the `Tokenizer.save_vocab` call failed due to a missing method in `bm25s` version 0.2.0. Updating `bm25s[core]` to version 0.2.1 and ensuring proper imports in `retriever.py` resolve the problem. 

Without this change, running the index builder throws: `AttributeError: 'Tokenizer' object has no attribute 'save_vocab'. Did you mean: 'reset_vocab'?`

## How to Test
Run the index builder with `bm25s` as backend.

## Changes
- Bumped dependency `bm25s[core]` from 0.2.0 to 0.2.1 in `requirements`.
- Added `import bm25s` to the `retriever.py` file where the BM25S searcher is used.
