### PR TITLE
Fix ConditionalPipeline component initialization

### DIFF
--- a/flashrag/pipeline/pipeline.py
+++ b/flashrag/pipeline/pipeline.py
@@ -141,9 +141,10 @@ class ConditionalPipeline(BasicPipeline):
 
         self.judger = get_judger(config)
         if generator is None:
-            self.generator = get_generator(config)
+            generator = get_generator(config)
         if retriever is None:
-            self.retriever = get_retriever(config)
+            retriever = get_retriever(config)
+
         self.generator = generator
         self.retriever = retriever
 


### PR DESCRIPTION
## Summary

- preserve default generator and retriever instances created by `ConditionalPipeline`
- pass the resolved component instances to the nested `SequentialPipeline`
- keep explicitly supplied components unchanged

## Root cause

`ConditionalPipeline.__init__` assigned newly created default components directly to instance attributes, then immediately overwrote those attributes with the original `None` arguments. The nested `SequentialPipeline` masked the problem by creating the components again, while the parent pipeline retained an inconsistent `None` retriever and generator.

Fixes #234.

## Validation

- `python -m py_compile flashrag/pipeline/pipeline.py`
- `git diff --check -- flashrag/pipeline/pipeline.py`

No regression test is included because this is a minimal, self-evident initialization fix.
