### PR TITLE
Fix Question typo in SelfAskPipeline

### DIFF
--- a/flashrag/pipeline/active_pipeline.py
+++ b/flashrag/pipeline/active_pipeline.py
@@ -855,7 +855,7 @@ class SelfAskPipeline(BasicPipeline):
                 self.P_INS
                 + "\n"
                 + self.format_reference(retrieval_result)
-                + f"\nQuesiton: {question}"
+                + f"\nQuestion: {question}"
                 + "\nAre follow up questions needed here: "
                 + follow_ups
                 + "\n"
@@ -891,7 +891,7 @@ class SelfAskPipeline(BasicPipeline):
             if "So the final answer is: " in gen_out:
                 res = (
                     self.format_reference(retrieval_result)
-                    + f"\nQuesiton: {question}"
+                    + f"\nQuestion: {question}"
                     + "\nAre follow up questions needed here: "
                     + follow_ups
                     + "\n"
@@ -904,7 +904,7 @@ class SelfAskPipeline(BasicPipeline):
         if not early_exit:
             res = (
                 self.format_reference(retrieval_result)
-                + f"\nQuesiton: {question}"
+                + f"\nQuestion: {question}"
                 + "\nAre follow up questions needed here: "
                 + follow_ups
                 + "\n"


### PR DESCRIPTION
## Summary

Correct the misspelled `Quesiton:` label to `Question:` in all three prompt construction paths of `SelfAskPipeline.run_item()`.

This keeps the dynamically constructed prompt consistent with the Self-Ask few-shot examples.

## Validation

- `python -m py_compile flashrag/pipeline/active_pipeline.py`
- `git diff --check`
- confirmed that `Quesiton` no longer appears in `active_pipeline.py`
