### PR TITLE
fix: update star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,4 +756,4 @@ Please kindly cite our paper if helps your research:
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=RUC-NLPIR/FlashRAG&type=Date)](https://star-history.com/#RUC-NLPIR/FlashRAG&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=RUC-NLPIR/FlashRAG&type=Date)](https://star-history.dera.page/#RUC-NLPIR/FlashRAG&Date)


### PR DESCRIPTION
The current star history chart in the README is broken due to GitHub stargazer API restrictions. This PR switches the chart to a working alternative that uses a different data source and requires no API token. The chart itself is unchanged visually; only the serving domain is updated.